### PR TITLE
Fix method signature for jailbreak_experiment

### DIFF
--- a/main.py
+++ b/main.py
@@ -91,7 +91,7 @@ def main():
             should_natural=args.natural,
             should_guard=args.guard,
             model_name=args.model,
-            **beam_params
+            beam_params=beam_params
         )
     elif args.experiment == "llama_guard":
         from adversarial_decoding.experiments.llama_guard_experiment import llama_guard_experiment


### PR DESCRIPTION
The `jailbreak_experiment` method uses a slightly different method signature from all the other experiments. This PR fixes the calling function accordingly. 

I considered changing the method signature of `jailbreak_experiment`, but I presume this was an intentional choice as the number of parameters that are passed to that experiment is more than that of the other methods? Happy to update that instead if we want consistency.